### PR TITLE
Persistent roles

### DIFF
--- a/sigma/core/mechanics/database.py
+++ b/sigma/core/mechanics/database.py
@@ -221,3 +221,39 @@ class Database(motor.AsyncIOMotorClient):
                 output = item
                 break
         return output
+
+    async def update_state(self, entity, **events):
+        """
+        Updates an existing state's value. Creates a state
+        if it does not exist. Also creates a database collection
+        for each entity type when needed.
+
+        :param entity: Any discord object with an id attribute
+        :param events: A dict of event states
+        """
+        if not(hasattr(entity, "id")):
+            raise TypeError(f"'{entity}' is not an Entity!")
+
+        collection = self[self.db_cfg.database][f'{entity.__class__.__name__}States']
+        await collection.update(
+            {f"{entity.__class__.__name__}ID": entity.id},
+            {"$set": events},
+            upsert=True
+        )
+
+    async def get_state(self, entity, event):
+        """
+        :param entity: Any discord object with an id attribute
+        :param event: An event passed as str
+        :return: Returns the state if found or returns None
+        """
+        if not(hasattr(entity, "id")):
+            raise TypeError(f"'{entity}' is not an Entity!")
+
+        collection = self[self.db_cfg.database][f'{entity.__class__.__name__}States']
+        record = await collection.find_one({f"{entity.__class__.__name__}ID": entity.id})
+        if record is None:
+            return record
+        else:
+            state = record[event]
+            return state

--- a/sigma/modules/moderation/server_settings/roles/autorole/module.yml
+++ b/sigma/modules/moderation/server_settings/roles/autorole/module.yml
@@ -67,6 +67,15 @@ commands:
       If the invite with that ID no longer exists on your server add ":f" to the end to force remove it.
       Please not that if you are force removing an invite that it is case sensitive.
 
+  - name:         rolepersist
+    alts:
+      - "persistrole"
+      - "rp"
+    enabled:      true
+    usage:        "{pfx}{cmd} true"
+    description:
+      Enable or disable the option to keep all roles of a member if they decide to rejoin the server.
+
 events:
   - name:         autorole_control
     type:         member_join
@@ -78,4 +87,12 @@ events:
 
   - name:         bound_role_control
     type:         member_join
+    enabled:      true
+
+  - name:         rolepersist_join_handler
+    type:         member_join
+    enabled:      true
+
+  - name:         rolepersist_update_handler
+    type:         member_update
     enabled:      true

--- a/sigma/modules/moderation/server_settings/roles/autorole/rolepersist.py
+++ b/sigma/modules/moderation/server_settings/roles/autorole/rolepersist.py
@@ -1,0 +1,38 @@
+import discord
+
+from sigma.core.mechanics.command import SigmaCommand
+
+
+async def rolepersist(cmd: SigmaCommand, message: discord.Message, args: list):
+    if message.author.permissions_in(message.channel).manage_guild:
+        if args:
+            if args[0].lower() == "true":
+                await cmd.db.set_guild_settings(message.guild.id, 'RolePersist', True)
+                response = discord.Embed(
+                    color=0x696969, title=f'🔍 Processing {message.guild.member_count} members.'
+                )
+                await message.channel.send(embed=response)
+
+                # Save all role ids for each member if the roles
+                # are lower than sigma's own highest role.
+                for member in message.guild.members:
+                    roles = list(filter(
+                        lambda role: role < message.guild.me.top_role,
+                        member.roles
+                    ))
+                    role_ids = [role.id for role in roles]
+                    await cmd.db.update_state(member, roles=role_ids)
+
+                response = discord.Embed(
+                    color=0x77B255, title='✅ All roles are now persistent.'
+                )
+            elif args[0].lower() == "false":
+                await cmd.db.set_guild_settings(message.guild.id, 'RolePersist', False)
+                response = discord.Embed(color=0x77B255, title=f'✅ Role persist has been disabled.')
+            else:
+                response = discord.Embed(color=0xBE1931, title=f'! Unrecognized argument.')
+        else:
+            response = discord.Embed(color=0xBE1931, title='❗ Role persist argument not provided.')
+    else:
+        response = discord.Embed(title='⛔ Access Denied. Manage Server needed.', color=0xBE1931)
+    await message.channel.send(embed=response)

--- a/sigma/modules/moderation/server_settings/roles/autorole/rolepersist_join_handler.py
+++ b/sigma/modules/moderation/server_settings/roles/autorole/rolepersist_join_handler.py
@@ -1,0 +1,15 @@
+import discord
+
+
+async def rolepersist_join_handler(ev, member):
+    persist_enabled = await ev.db.get_guild_settings(member.guild.id, 'RolePersist')
+    if persist_enabled is not True:
+        return
+    all_role_ids = await ev.db.get_state(member, 'roles')
+    if all_role_ids and len(all_role_ids) > 1:
+        for persist_role in all_role_ids[1:]:
+            role = discord.utils.find(lambda x: x.id == persist_role, member.guild.roles)
+
+            # Need to figure out why using a list of
+            # Role objects gives an 'id' attribute error
+            await member.add_roles(role)  # No reason key, to prevent log spam.

--- a/sigma/modules/moderation/server_settings/roles/autorole/rolepersist_update_handler.py
+++ b/sigma/modules/moderation/server_settings/roles/autorole/rolepersist_update_handler.py
@@ -1,6 +1,3 @@
-import discord
-
-
 async def rolepersist_update_handler(ev, before, after):
     persist_enabled = await ev.db.get_guild_settings(after.guild.id, 'RolePersist')
     if persist_enabled is not True:

--- a/sigma/modules/moderation/server_settings/roles/autorole/rolepersist_update_handler.py
+++ b/sigma/modules/moderation/server_settings/roles/autorole/rolepersist_update_handler.py
@@ -1,0 +1,10 @@
+import discord
+
+
+async def rolepersist_update_handler(ev, before, after):
+    persist_enabled = await ev.db.get_guild_settings(after.guild.id, 'RolePersist')
+    if persist_enabled is not True:
+        return
+    if before.roles != after.roles:
+        role_ids = [role.id for role in after.roles]
+        await ev.db.update_state(after, roles=role_ids)


### PR DESCRIPTION
This module will allow peristent roles. On enabling this module, it will save all roles lower than sigma's own top role into a db collection. Then the roles will be restored when a member rejoins the servers.

![RolePersist Module](https://i.imgur.com/Qev1RuA.png)