### PR TITLE
Update permission denied log format

### DIFF
--- a/sigma/core/mechanics/command.py
+++ b/sigma/core/mechanics/command.py
@@ -175,13 +175,6 @@ class SigmaCommand(object):
             log_text += f' | ARGS: {" ".join(args)}'
         self.log.info(log_text)
 
-    def log_unpermitted(self, perms: GlobalCommandPermissions):
-        log_text = f'ACCESS DENIED | '
-        log_text += f'BUSR: {perms.black_user} | MDL: {perms.module_denied} | BSRV: {perms.black_srv} | '
-        log_text += f'OWNR: {perms.owner_denied} | DM: {perms.dm_denied} | NSFW: {perms.nsfw_denied} | '
-        log_text += f'VIP: {perms.partner_denied}'
-        self.log.warning(log_text)
-
     async def add_usage_exp(self, message: discord.Message):
         if message.guild:
             if not await self.bot.cool_down.on_cooldown('UsageExperience', message.author):
@@ -307,7 +300,7 @@ class SigmaCommand(object):
                         self.log.warning('ACCESS DENIED: This module or command is not allowed in this location.')
                         await self.respond_with_icon(message, '⛔')
                 else:
-                    self.log_unpermitted(perms)
+                    perms.log_unpermitted()
                     await self.respond_with_icon(message, '⛔')
                     if perms.response:
                         try:

--- a/sigma/core/mechanics/permissions.py
+++ b/sigma/core/mechanics/permissions.py
@@ -156,6 +156,39 @@ class GlobalCommandPermissions(object):
                 self.permitted = False
                 break
 
+    def log_unpermitted(self):
+        """
+        ### Flags:
+            - `u`: User Blacklisted
+            - `s`: Server Blacklisted
+            - `o`: Owner Only
+            - `m`: Module Blacklisted
+            - `d`: Direct Message Not Allowed
+            - `n`: NSFW Channels Only
+            - `v`: Parter Only
+        ### Example:
+            `u---dn-` *User blacklisted, use in DM and use of NSFW command when not in NSFW channel.*
+        """
+
+        conds = [
+            self.black_user,
+            self.black_srv,
+            self.owner_denied,
+            self.module_denied,
+            self.dm_denied,
+            self.nsfw_denied,
+            self.partner_denied
+        ]
+        letters = ['u', 's', 'o', 'm', 'd', 'n', 'v']
+        fmt = ''.join(map(lambda c, l: l if c else '-', conds, letters))
+
+        self.cmd.log.warning((
+            f'ACCESS DENIED'
+            f' | {fmt}'
+            f' | USR: {self.message.author} ({self.message.author.id})'
+            f' | SRV: {self.message.guild} ({self.message.guild.id})'
+        ))
+
 
 class ServerCommandPermissions(object):
     def __init__(self, command, message: discord.Message):


### PR DESCRIPTION
Will now print an UNIX-like permission format.
The format looks like the one for file permissions.

Example:
All denied:      `usomdnv`
Only NSFW:       `-----n-`
User and Server: `us-----`