### PR TITLE
Remove rogue "add resource" line

### DIFF
--- a/sigma/modules/owner_controls/resources/destroyresource.py
+++ b/sigma/modules/owner_controls/resources/destroyresource.py
@@ -38,7 +38,6 @@ async def destroyresource(cmd, pld):
                     res_nam = 'currency' if pld.args[0].lower() == currency else pld.args[0].lower()
                     valid_res = f'{res_nam.title()}Resource' in await cmd.db[cmd.db.db_nam].list_collection_names()
                     if valid_res:
-                        await cmd.db.add_resource(target.id, res_nam, amount, cmd.name, pld.msg, False)
                         target_amount = await cmd.db.get_resource(target.id, res_nam)
                         target_amount = target_amount.current
                         if amount <= target_amount:


### PR DESCRIPTION
In sigma/modules/owner_controls/resources/destroyresource.py, I spotted this at line 41:
`await cmd.db.add_resource(target.id, res_nam, amount, cmd.name, pld.msg, False)`
Just reading over the code and the commit, it looks as if while the check for if the resource was valid was added to generateresource.py and destroyresource.py, this line was accidentally added to the latter, which should hypothetically cause no changes at all if the command executes successfully, since the bot would give a user x resources and then immediately take it away.